### PR TITLE
Add EIP-55 checking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.0.0
+          - 3.0.3
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    siwe (1.0.0)
+    siwe (1.1.0)
       eth (~> 0.5.1)
 
 GEM
@@ -22,7 +22,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    ipaddr (1.2.3)
+    ipaddr (1.2.4)
     jaro_winkler (1.5.4)
     keccak (1.3.0)
     konstructor (1.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    siwe (1.1.1)
+    siwe (1.1.2)
       eth (~> 0.5.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    siwe (1.1.0)
+    siwe (1.1.1)
       eth (~> 0.5.1)
 
 GEM
@@ -30,7 +30,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    mini_portile2 (2.7.1)
+    mini_portile2 (2.8.0)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     openssl (2.2.1)

--- a/lib/siwe.rb
+++ b/lib/siwe.rb
@@ -9,6 +9,7 @@ module Siwe
   autoload :ExpiredMessage, "siwe/exceptions"
   autoload :NotValidMessage, "siwe/exceptions"
   autoload :InvalidSignature, "siwe/exceptions"
+  autoload :InvalidAddress, "siwe/exceptions"
 
   class Error < StandardError; end
 end

--- a/lib/siwe/exceptions.rb
+++ b/lib/siwe/exceptions.rb
@@ -8,6 +8,13 @@ module Siwe
     end
   end
 
+  # Used when the address does not conform to EIP-55 or is invalid.
+  class InvalidAddress < StandardError
+    def initialize(msg = "Address does not conform to EIP-55 or is invalid.")
+      super
+    end
+  end
+
   # Used when the message is not yet valid. (Not Before > Time.now)
   class NotValidMessage < StandardError
     def initialize(msg = "Message not yet valid.")

--- a/lib/siwe/message.rb
+++ b/lib/siwe/message.rb
@@ -164,7 +164,6 @@ module Siwe
 
       raise Siwe::InvalidAddress unless @address.eql?(Eth::Address.new(@address).to_s)
 
-      puts "whatever"
       begin
         pub_key = Eth::Signature.personal_recover prepare_message, signature
         signature_address = Eth::Util.public_key_to_address pub_key

--- a/lib/siwe/message.rb
+++ b/lib/siwe/message.rb
@@ -76,10 +76,15 @@ module Siwe
 
     def initialize(domain, address, uri, version, options = {})
       @domain = domain
-      @address = address
+      begin
+        @address = Eth::Address.new(address).to_s
+      rescue StandardError
+        raise Siwe::InvalidAddress
+      end
+      raise Siwe::InvalidAddress unless @address.eql? address
+
       @uri = uri
       @version = version
-
       @statement = options.fetch :statement, ""
       @issued_at = options.fetch :issued_at, Time.now.utc.iso8601
       @nonce = options.fetch :nonce, Siwe::Util.generate_nonce
@@ -94,7 +99,7 @@ module Siwe
       if (message = msg.match SIWE_MESSAGE)
         new(
           message[:domain],
-          message[:address],
+          Eth::Address.new(message[:address]).to_s,
           message[:uri],
           message[:version],
           {
@@ -117,7 +122,7 @@ module Siwe
     def to_json_string
       obj = {
         domain: @domain,
-        address: @address,
+        address: Eth::Address.new(@address).to_s,
         uri: @uri,
         version: @version,
         chain_id: @chain_id,
@@ -157,6 +162,9 @@ module Siwe
 
       raise Siwe::InvalidSignature if signature.empty?
 
+      raise Siwe::InvalidAddress unless @address.eql?(Eth::Address.new(@address).to_s)
+
+      puts "whatever"
       begin
         pub_key = Eth::Signature.personal_recover prepare_message, signature
         signature_address = Eth::Util.public_key_to_address pub_key

--- a/lib/siwe/version.rb
+++ b/lib/siwe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Siwe
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/lib/siwe/version.rb
+++ b/lib/siwe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Siwe
-  VERSION = "1.0.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Introduces a new error type `Siwe::InvalidAddress` that is raised when a non EIP-55 conformant address is used to either build a new message or validate one. Closes #11 